### PR TITLE
Adds the ability to filter by HAVING when the query is grouped

### DIFF
--- a/lib/querify.rb
+++ b/lib/querify.rb
@@ -30,7 +30,7 @@ module Querify
 		attr_accessor :params
 		attr_accessor :headers
 		attr_accessor :columns
-		attr_accessor :filters
+		attr_accessor :where_filters, :having_filters
 		attr_accessor :sorts
 
 		def config

--- a/lib/querify/exceptions.rb
+++ b/lib/querify/exceptions.rb
@@ -3,6 +3,9 @@ module Querify
 	# General error class
 	class Error < StandardError; end;
 
+	# Thrown when providing a HAVING filter before a GROUP BY clause
+	class QueryNotYetGrouped < Error; end;
+
 	# Thrown when an invalid operator is given to a filter
 	class InvalidOperator < Error; end
 


### PR DESCRIPTION
URL syntax is just like the WHERE filters:

```
/posts?having[column][:eq]=value
```

HAVING filters are only applied if the query has **_already**_ been grouped. 
